### PR TITLE
Remove deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,3 @@
 # itisatrap
 
 Site behind <http://itisatrap.org>.
-
-## Deployment
-
-To request a prod push of your latest code:
-
-* File a bug in `Infrastructure & Operations -> WebOps Other`
-* State you would like to push master of https://github.com/mozilla/itisatrap to prod http://www.itisatrap.org/


### PR DESCRIPTION
This repo is now automatically deployed when it changes:

  https://bugzilla.mozilla.org/show_bug.cgi?id=1226746

This effectively reverts f1beb31fba1f30365d23bd278152e8106e1b64ca.