### PR TITLE
Revert "Add a test for the DNT-compliant list"

### DIFF
--- a/css/its-a-trap.css
+++ b/css/its-a-trap.css
@@ -62,9 +62,3 @@
     color: green;
     font-weight: bold;
 }
-
-#dntcompliant-loaded {
-    border: none;
-    height: 1.3em;
-    width: 13em;
-}

--- a/firefox/its-a-tracker.html
+++ b/firefox/its-a-tracker.html
@@ -34,14 +34,12 @@
                 <div id="main-content">
                     <p>OK, not really, but Web trackers are out there on the Internet. This is a test page for Firefox's built-in <a href="https://support.mozilla.org/kb/tracking-protection-firefox">Tracking Protection</a>.</p>
 
-                    <p>If you're running Firefox 42 or later and viewing this page in a Private Window, you should see a shield icon in the URL bar and the first two (all three on Firefox 49 or later) of these should be green:</p>
+                    <p>If you're running Firefox 42 or later and viewing this page in a Private Window, you should see a shield icon in the URL bar and both of these should be green:</p>
 
                     <div id="tests">
                         <ul class="trackers">
                             <li>a simulated third-party tracker was <span id="blacklisted-waiting">...</span><span id="blacklisted-blocked" class="correct hidden">correctly blocked</span><span id="blacklisted-loaded" class="incorrect hidden">incorrectly loaded</span></li>
                             <li>a simulated first-party tracker was <span id="whitelisted-waiting">...</span><span id="whitelisted-loaded" class="correct hidden">correctly loaded</span><span id="whitelisted-blocked" class="incorrect hidden">incorrectly blocked</span></li>
-                            <li id="dntcompliant-test">a simulated DNT-compliant third-party tracker was <span id="dntcompliant-waiting">...</span><iframe id="dntcompliant-loaded" class="hidden"></iframe><span id="dntcompliant-blocked" class="incorrect hidden">incorrectly blocked</span></li>
-                            <li id="dntcompliant-warning" class="hidden">You have DNT enabled globally, we can't test whether or not DNT-compliant trackers receive the header.</li>
                         </ul>
                     </div>
 

--- a/js/its-a-tracker.js
+++ b/js/its-a-tracker.js
@@ -22,23 +22,3 @@ whitelisted.onerror = function () {
     toggleStatus("whitelisted", "blocked");
 };
 whitelisted.src = "https://itisatracker.org/tracker.js";
-
-var dntcompliant = window.document.getElementById("dntcompliant-loaded");
-var dntcompliantLoaded = false;
-dntcompliant.onload = function () {
-    dntcompliantLoaded = true;
-    toggleStatus("dntcompliant", "loaded");
-};
-setTimeout(function () {
-    if (!dntcompliantLoaded) {
-        toggleStatus("dntcompliant", "blocked");
-    }
-}, 3000);
-dntcompliant.src = "https://dntcompliant.org/check-dnt.html";
-
-if (navigator.doNotTrack == "yes" || navigator.doNotTrack == "1") {
-  var test = window.document.getElementById("dntcompliant-test");
-  var warning = window.document.getElementById("dntcompliant-warning");
-  test.classList.add("hidden");
-  warning.classList.remove("hidden");
-}


### PR DESCRIPTION
This reverts commit 31cc61f88a065e40cdc34f2ce8ee23fc2ccb054a.

We changed to [a different approach](https://bugzilla.mozilla.org/show_bug.cgi?id=1258033#c1) so this test is no longer relevant.