### PR TITLE
Update Flash block pages to account for changed functionality

### DIFF
--- a/firefox/flashblock-subdocument.html
+++ b/firefox/flashblock-subdocument.html
@@ -49,9 +49,9 @@
                             <td><object data="/swf/failure.swf"></object></td>
                         </tr>
                         <tr>
-                            <td>Subdocument Blocked</td>
-                            <td><!-- Display nothing here. Blocked plugins are not displayed --></td>
-                            <td><iframe src="https://flashsubdoc.itisatrap.org/firefox/flashblock-failure-frame.html" scrolling="no" frameBorder="0" seamless='seamless'></iframe></td>
+                            <td>Blocked subdocument in a non-third-party context</td>
+                            <td><img src="/img/flash-cta.png"></td>
+                            <td><iframe src="/firefox/flashblock-failure-frame.html" scrolling="no" frameBorder="0" seamless='seamless'></iframe></td>
                         </tr>
                         <tr>
                             <td>Subdocument Block Exception</td>

--- a/firefox/flashblock.html
+++ b/firefox/flashblock.html
@@ -74,6 +74,16 @@
                             <td><!-- Display nothing here. Blocked plugins are not displayed --></td>
                             <td><iframe src="https://flashblock.itisatrap.org/firefox/flashblock-parent-of-whitelisted-frame.html" scrolling="no" frameBorder="0" seamless='seamless'></iframe></td>
                         </tr>
+                        <tr>
+                            <td>Blocked Third-Party site</td>
+                            <td><!-- Display nothing here. Blocked plugins are not displayed --></td>
+                            <td><iframe src="https://flashsubdoc.itisatrap.org/firefox/flashblock-failure-frame.html" scrolling="no" frameBorder="0" seamless='seamless'></iframe></td>
+                        </tr>
+                        <tr>
+                            <td>Subdocument Block Exception</td>
+                            <td><img src="/img/flash-cta.png"></td>
+                            <td><iframe src="https://except.flashsubdoc.itisatrap.org/firefox/flashblock-failure-frame.html" scrolling="no" frameBorder="0" seamless='seamless'></iframe></td>
+                        </tr>
                     </table>
 
                     <div id="download">

--- a/firefox/flashblock.html
+++ b/firefox/flashblock.html
@@ -75,7 +75,7 @@
                             <td><iframe src="https://flashblock.itisatrap.org/firefox/flashblock-parent-of-whitelisted-frame.html" scrolling="no" frameBorder="0" seamless='seamless'></iframe></td>
                         </tr>
                         <tr>
-                            <td>Blocked Third-Party site</td>
+                            <td>Blocked Subdocument in Third-party context</td>
                             <td><!-- Display nothing here. Blocked plugins are not displayed --></td>
                             <td><iframe src="https://flashsubdoc.itisatrap.org/firefox/flashblock-failure-frame.html" scrolling="no" frameBorder="0" seamless='seamless'></iframe></td>
                         </tr>


### PR DESCRIPTION
The subdocument blocklist now functions instead as a third-party blocklist. itisatrap.org should be updated to reflect this. See [Bug 1345611](https://bugzilla.mozilla.org/show_bug.cgi?id=1345611) for details.